### PR TITLE
Add class to properly read the ESP32's ADC

### DIFF
--- a/src/analog_reader.h
+++ b/src/analog_reader.h
@@ -1,0 +1,61 @@
+#ifndef _analog_reader_H_
+#define _analog_reader_H_
+
+#include <Arduino.h>
+#if defined(ESP32)
+#include "esp_adc_cal.h"
+#endif
+
+/**
+ * @brief ESP32AnalogReader does all of the calibration of the ESP32's ADC, using the
+ * Vref of the specific chip. If you don't do this, the values from analogRead() are
+ * all over the place!
+ * 
+ * Also does the reading of the value, in mV.
+ * 
+ * Copied from SensESP - thanks, @mairas!
+ */
+
+class ESP32AnalogReader {
+ private:
+  uint8_t pin_;
+  adc_atten_t attenuation_ = ADC_ATTEN_DB_11;
+  adc_bits_width_t bit_width_ = ADC_WIDTH_BIT_12;
+  // maximum voltage readout for 3.3V VDDA when attenuation_ is set to 11 dB
+  const float kVmax_ = 3300;
+  int output_scale_;
+  int8_t adc_channel_;
+  esp_adc_cal_characteristics_t adc_characteristics_;
+  const int kVref_ = 1100;  // voltage reference, in mV
+
+ public:
+  ESP32AnalogReader(uint8_t pin) : pin_{pin} {
+    if (!(32 <= pin_ && pin_ <= 39)) {
+      Serial.println("Only ADC1 is supported at the moment");
+      adc_channel_ = -1;
+      return;
+    }
+    adc_channel_ = digitalPinToAnalogChannel(pin_);
+  }
+
+  // This is all the calibration stuff
+  bool configure() {
+    if (adc_channel_ == -1) {
+      return false;
+    }
+    adc1_config_width(bit_width_);
+    adc1_config_channel_atten((adc1_channel_t)adc_channel_, attenuation_);
+    esp_adc_cal_characterize(ADC_UNIT_1, attenuation_, bit_width_, kVref_,
+                             &adc_characteristics_);
+    return true;
+  }
+
+  float read() {
+    uint32_t voltage_in_mV;
+    esp_adc_cal_get_voltage((adc_channel_t)adc_channel_, &adc_characteristics_,
+                            &voltage_in_mV);
+    return voltage_in_mV / 1000.0; 
+  }
+};
+
+#endif // _analog_reader_H_

--- a/src/functions.h
+++ b/src/functions.h
@@ -18,47 +18,6 @@ float voltage_multiplier(float end_volts, int R1, int R2) {
 }
 
 /**
- * @brief - get_battery_voltage() - reads the voltage_measurement_pin and converts
- * the average of all the reads to voltage, then converts the voltage back into the original
- * measured voltage, prior to the physical voltage divider circuit.
- * 
- * @return - returns a float that is the original measured voltage.
-*/
-
-float get_battery_voltage(uint8_t voltage_read_pin, float calibration_value) {
-  int read_delay = 20;
-  int num_samples = 100;
-  double average_ADC_value = 0.0;
-  float voltage_value = 0.0;
-
-  // Calculate an avg of num_samples analogRead values taken read_delay ms apart
-  for (int i = 0; i < num_samples; i++) {
-    average_ADC_value += analogRead(voltage_read_pin);
-    delay(read_delay);
-  }
-  average_ADC_value = average_ADC_value / num_samples;
-  Serial.print("average_ADC_value: ");
-  Serial.println(average_ADC_value);
-
-  // Convert avg analogRead value (0 - 4095) to voltage
-  voltage_value = (float)(average_ADC_value / 4096 * 3.3);
-  Serial.print("voltage_value: ");
-  Serial.println(voltage_value);
-
-  // Convert average measured voltage to voltage before the voltage divider
-  // IOW, reverse the effect of the voltage divider
-  // BUT, it doesn't work, because I think there's a problem with the physical circuit,
-  // based on my measurement of the actual voltage being measured and of the ohms value
-  // of the physical resistors in the circuit.
-  // voltage_value = voltage_multiplier(voltage_value, 9420, 2143);
-  // For now, use the calculated calibration_value (the value necessary to make the output accurate)
-  voltage_value = voltage_value * calibration_value;
-  Serial.print("final voltage_value: ");
-  Serial.println(voltage_value);
-  return voltage_value;
-}
-
-/**
  * @brief - prepare_hibernation() tells the ESP all the things to turn off when the
  * "deep sleep" command is issued. 
  */


### PR DESCRIPTION
This modification calibrates the ADC very well. A calibration multiplier is still needed, but it's due to something in the hardware, not in the ADC - I checked at a bunch of different values and it was always within 1/2%.

Copied from SensESP - thanks @mairas!